### PR TITLE
fix(resources): drop CPU limits (restore no-CPU-limits posture)

### DIFF
--- a/kubernetes/apps/default/hydra-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hydra-server/app/helmrelease.yaml
@@ -48,7 +48,6 @@ spec:
               requests:
                 cpu: 1000m
               limits:
-                cpu: 4000m
                 memory: 1Gi
             probes:
               liveness:

--- a/kubernetes/apps/default/languagetool/app/helmrelease.yaml
+++ b/kubernetes/apps/default/languagetool/app/helmrelease.yaml
@@ -49,7 +49,6 @@ spec:
                 cpu: 1000m
                 memory: 2Gi
               limits:
-                cpu: 4000m
                 memory: 10Gi
             probes:
               liveness:

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -29,7 +29,6 @@ spec:
       egress.cilium.io/auth: "true"
     resources:
       limits:
-        cpu: 2000m
         memory: 1Gi
       requests:
         cpu: 100m

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -19,22 +19,16 @@ spec:
       resources:
         requests:
           cpu: 200m
-        limits:
-          cpu: 800m
     gc:
       resources:
         requests:
           cpu: 20m
-        limits:
-          cpu: 800m
     worker:
       annotations:
         configmap.reloader.stakater.com/reload: "nfd-worker-conf"
       resources:
         requests:
           cpu: 20m
-        limits:
-          cpu: 800m
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
         cpu: 15m
         memory: 64M
       limits:
-        cpu: 100m
         memory: 64M
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary
Direct follow-up to #1963 (Kyverno removal). The deleted `delete-cpu-limits` ClusterPolicy was silently stripping CPU limits at admission; now those limits are enforced, capping workloads that previously burst freely. This restores the no-CPU-limits posture by removing the CPU limit lines (memory limits and all requests preserved).

## Changes (5 charts, -10 lines)
| Chart | Removed CPU limit |
|-------|-------------------|
| `default/hydra-server` | `4000m` |
| `default/languagetool` | `4000m` |
| `flux-system/flux-operator` | `2000m` |
| `kube-system/node-feature-discovery` | `800m` ×3 (master, gc, worker) |
| `observability/exporters/blackbox-exporter` | `100m` |

## Verification
All 5 HelmReleases build cleanly via `kustomize build`.